### PR TITLE
Fix getting repo url for installation example

### DIFF
--- a/web.go
+++ b/web.go
@@ -946,10 +946,11 @@ var distTmpl = `
 			
 			<script>
 				document.addEventListener("DOMContentLoaded", function () {
+					var url = window.location.toString().match(/^(.*)\/packages\/.+?$/)[1];
 					document.getElementById("repo-url").innerHTML = "";
-					document.getElementById("repo-url").innerText = window.location.toString().split("/packages")[0];
+					document.getElementById("repo-url").innerText = url;
 					document.getElementById("repo-key-url").innerHTML = "";
-					document.getElementById("repo-key-url").innerText = window.location.toString().split("/packages")[0] + "/key.asc";
+					document.getElementById("repo-key-url").innerText = url + "/key.asc";
 				});
 			</script>
 		</div> 


### PR DESCRIPTION
The script works incorrect if domain name contains `packages`, like this: `packages.coex.tech`. It incorrectly determines the base URL so installation example would like like this:

<img width="609" alt="106351834-bf3bb880-62ef-11eb-8b50-eb16a314aff3" src="https://user-images.githubusercontent.com/1683279/106357302-54ea3e80-6316-11eb-83b5-2c5c96e33167.png">

Also it would work incorrect if the distribution name is `packages`, so the full URL would like `http://packages.coex.tech/packages/packages/`.

Finally, the base URL of the repo also can contain `packages` word, so the full URL would be `http://packages.coex.tech/packages/packages/buster/`, which also would cause an incorrect installation hint.

Proposed solution solves all the problems using a simple regular expression.